### PR TITLE
Avoid calling unwrap in unexpected cases

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -286,7 +286,7 @@ impl RedditClient {
 impl Drop for RedditClient {
     fn drop(&mut self) {
         if self.auto_logout {
-            self.get_authenticator().logout(&self.client, &self.user_agent).unwrap();
+            let _ = self.get_authenticator().logout(&self.client, &self.user_agent);
         }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -60,7 +60,7 @@ impl RedditClient {
     /// Creates an instance of the `RedditClient` using the provided user agent.
     pub fn new(user_agent: &str,
                authenticator: Arc<Mutex<Box<Authenticator + Send>>>)
-               -> RedditClient {
+               -> Result<RedditClient, APIError> {
         // Connection pooling is problematic if there are pauses/sleeps in the program, so we
         // choose to disable it by using a non-pooling connector.
         let client = Client::with_connector(DefaultConnector::default());
@@ -72,10 +72,9 @@ impl RedditClient {
             auto_logout: true,
         };
 
-        this.get_authenticator()
-            .login(&this.client, &this.user_agent)
-            .expect("Authentication failed. Did you use the correct username/password?");
-        this
+        try!(this.get_authenticator()
+            .login(&this.client, &this.user_agent));
+        Ok(this)
     }
 
     /// Disables the automatic logout that occurs when the client drops out of scope.
@@ -88,7 +87,8 @@ impl RedditClient {
     /// ```rust,no_run
     /// use rawr::client::RedditClient;
     /// use rawr::auth::PasswordAuthenticator;
-    /// let mut client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d"));
+    /// let mut client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c",
+    /// "d")).unwrap();
     /// client.set_auto_logout(false); // Auto-logout disabled. Set to `true` to enable.
     /// ```
     pub fn set_auto_logout(&mut self, val: bool) {
@@ -233,7 +233,7 @@ impl RedditClient {
     /// ```
     /// # use rawr::client::RedditClient;
     /// # use rawr::auth::AnonymousAuthenticator;
-    /// # let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// # let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// assert_eq!(client.url_escape(String::from("test&co")), String::from("test%26co"));
     /// assert_eq!(client.url_escape(String::from("👍")), String::from("%F0%9F%91%8D"));
     /// assert_eq!(client.url_escape(String::from("\n")), String::from("%0A"))
@@ -259,7 +259,7 @@ impl RedditClient {
     /// # Examples
     /// ```
     /// use rawr::prelude::*;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let post = client.get_by_id("t3_4uule8").get().expect("Could not get post.");
     /// assert_eq!(post.title(), "[C#] Abstract vs Interface");
     /// ```
@@ -272,7 +272,7 @@ impl RedditClient {
     /// # Examples
     /// ```rust,no_run
     /// use rawr::prelude::*;
-    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d"));
+    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d")).unwrap();
     /// let messages = client.messages();
     /// for message in messages.unread(ListingOptions::default()) {
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! ```rust,no_run
 //! use rawr::client::RedditClient;
 //! use rawr::auth::AnonymousAuthenticator;
-//! let client = RedditClient::new("my user agent", AnonymousAuthenticator::new());
+//! let client = RedditClient::new("my user agent", AnonymousAuthenticator::new()).unwrap();
 //! ```
 //!
 //! It is important that you pick a good user agent. The ideal format is
@@ -31,7 +31,7 @@
 //! ```rust,no_run
 //! # use rawr::client::RedditClient;
 //! # use rawr::auth::AnonymousAuthenticator;
-//! let client = RedditClient::new("?:rawr:doc-tests", AnonymousAuthenticator::new());
+//! let client = RedditClient::new("?:rawr:doc-tests", AnonymousAuthenticator::new()).unwrap();
 //! let all = client.subreddit("all");
 //! ```
 //!
@@ -53,7 +53,7 @@
 //! # use rawr::client::RedditClient;
 //! # use rawr::auth::AnonymousAuthenticator;
 //! use rawr::options::ListingOptions;
-//! # let client = RedditClient::new("?:rawr:doc-tests", AnonymousAuthenticator::new());
+//! # let client = RedditClient::new("?:rawr:doc-tests", AnonymousAuthenticator::new()).unwrap();
 //! # let all = client.subreddit("all");
 //! let listing = all.hot(ListingOptions::default()).expect("Request unsuccessful");
 //! ```
@@ -75,7 +75,7 @@
 //! # use rawr::client::RedditClient;
 //! # use rawr::auth::AnonymousAuthenticator;
 //! # use rawr::options::ListingOptions;
-//! # let client = RedditClient::new("?:rawr:doc-tests", AnonymousAuthenticator::new());
+//! # let client = RedditClient::new("?:rawr:doc-tests", AnonymousAuthenticator::new()).unwrap();
 //! # let all = client.subreddit("all");
 //! let listing = all.hot(ListingOptions::default()).expect("Could not fetch posts");
 //! for post in listing {
@@ -96,7 +96,7 @@
 //! # use rawr::client::RedditClient;
 //! # use rawr::options::ListingOptions;
 //! use rawr::traits::{Commentable, Content};
-//! # let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+//! # let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
 //! let all = client.subreddit("all");
 //! for post in all.hot(ListingOptions::default()).expect("Request failed") {
 //!     if let Some(comment) = post.replies().expect("Could not get replies").next() {
@@ -123,7 +123,7 @@
 //! # use rawr::client::RedditClient;
 //! # use rawr::options::ListingOptions;
 //! # use rawr::traits::{Commentable, Content};
-//! # let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+//! # let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
 //! let all = client.subreddit("all");
 //! let mut listing = all.hot(ListingOptions::default()).expect("Request failed");
 //! if let Some(top_post) = listing.next() {
@@ -165,7 +165,7 @@
 //! # use rawr::options::ListingOptions;
 //! # use rawr::traits::{Commentable, Content};
 //! use rawr::options::LinkPost;
-//! # let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+//! # let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
 //! let programming = client.subreddit("programming");
 //! let post = LinkPost::new("I love Rust!", "https://rust-lang.org");
 //! programming.submit_link(post).expect("Could not submit link!");
@@ -180,7 +180,7 @@
 //! # use rawr::options::ListingOptions;
 //! # use rawr::traits::{Commentable, Content};
 //! use rawr::options::SelfPost;
-//! # let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+//! # let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
 //! let programming = client.subreddit("programming");
 //! let post = SelfPost::new("I love Rust!", "It's great! **Wow**!");
 //! programming.submit_text(post).expect("Could not submit link!");
@@ -226,7 +226,8 @@ mod tests {
     use auth::AnonymousAuthenticator;
     #[test]
     fn hot_length() {
-        let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+        let client = RedditClient::new("rawr", AnonymousAuthenticator::new())
+            .unwrap();
         let r_all = client.subreddit("all");
         let hot = r_all.hot(ListingOptions::default()).expect("Request failed!");
         let hot_list = hot.take(26).collect::<Vec<Submission>>();

--- a/src/structures/comment_list.rs
+++ b/src/structures/comment_list.rs
@@ -23,7 +23,7 @@ use traits::Content;
 /// use rawr::options::ListingOptions;
 /// use rawr::traits::Commentable;
 /// use rawr::auth::AnonymousAuthenticator;
-/// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+/// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
 /// let announcements = client.subreddit("announcements");
 /// let announcement = announcements.hot(ListingOptions::default())
 ///     .expect("Could not fetch announcements")

--- a/src/structures/listing.rs
+++ b/src/structures/listing.rs
@@ -16,7 +16,7 @@ use errors::APIError;
 /// use rawr::client::RedditClient;
 /// use rawr::options::ListingOptions;
 /// use rawr::auth::AnonymousAuthenticator;
-/// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+/// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
 /// let sub = client.subreddit("redditdev");
 /// let mut hot = sub.hot(ListingOptions::default()).expect("Could not get hot posts");
 /// for post in hot.take(500) {

--- a/src/structures/messages.rs
+++ b/src/structures/messages.rs
@@ -174,7 +174,7 @@ impl<'a> MessageInterface<'a> {
     /// # Examples
     /// ```rust,no_run
     /// use rawr::prelude::*;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// client.messages().compose("Aurora0001", "Test", "Hi!");
     // ```
     pub fn compose(&self, recipient: &str, subject: &str, body: &str) -> Result<(), APIError> {
@@ -206,7 +206,7 @@ impl<'a> MessageInterface<'a> {
     /// # Examples
     /// ```rust,no_run
     /// use rawr::prelude::*;
-    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d"));
+    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d")).unwrap();
     /// for message in client.messages().unread_stream() {
     ///     println!("New message received.");
     /// }

--- a/src/structures/submission.rs
+++ b/src/structures/submission.rs
@@ -192,7 +192,7 @@ impl<'a> Submission<'a> {
     /// # Examples
     /// ```rust,no_run
     /// use rawr::prelude::*;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let sub = client.subreddit("all");
     /// let mut listing = sub.hot(ListingOptions::default()).expect("Could not fetch listing!");
     /// let post = listing.nth(0).unwrap();
@@ -423,7 +423,7 @@ impl FlairList {
     /// use rawr::auth::PasswordAuthenticator;
     /// use rawr::options::ListingOptions;
     /// use rawr::traits::Flairable;
-    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d"));
+    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d")).unwrap();
     /// let sub = client.subreddit("learnprogramming");
     /// let post = sub.hot(ListingOptions::default()).unwrap().next().unwrap();
     /// // NOTE: this would 403 unless you are a moderator or the creator of the post.

--- a/src/structures/subreddit.rs
+++ b/src/structures/subreddit.rs
@@ -48,7 +48,7 @@ impl<'a> Subreddit<'a> {
     /// use rawr::client::RedditClient;
     /// use rawr::options::ListingOptions;
     /// use rawr::auth::AnonymousAuthenticator;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let sub = client.subreddit("askreddit");
     /// let hot = sub.hot(ListingOptions::default());
     /// ```
@@ -61,7 +61,7 @@ impl<'a> Subreddit<'a> {
     /// # Examples
     /// ```rust,no_run
     /// use rawr::prelude::*;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let askreddit = client.subreddit("askreddit");
     /// for post in askreddit.new_stream() {
     ///
@@ -79,7 +79,7 @@ impl<'a> Subreddit<'a> {
     /// use rawr::options::ListingOptions;
     /// use rawr::traits::Content;
     /// use rawr::auth::AnonymousAuthenticator;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let sub = client.subreddit("programming");
     /// let mut new = sub.new(ListingOptions::default()).expect("Could not get new feed");
     /// assert_eq!(new.next().unwrap().subreddit().name, "programming");
@@ -95,7 +95,7 @@ impl<'a> Subreddit<'a> {
     /// use rawr::client::RedditClient;
     /// use rawr::options::ListingOptions;
     /// use rawr::auth::AnonymousAuthenticator;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let sub = client.subreddit("thanksobama");
     /// let rising = sub.rising(ListingOptions::default()).unwrap();
     /// assert_eq!(rising.count(), 0);
@@ -113,7 +113,7 @@ impl<'a> Subreddit<'a> {
     /// use rawr::client::RedditClient;
     /// use rawr::options::{ListingOptions, TimeFilter};
     /// use rawr::auth::AnonymousAuthenticator;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let sub = client.subreddit("thanksobama");
     /// let mut top = sub.top(ListingOptions::default(), TimeFilter::AllTime)
     ///     .expect("Request failed");
@@ -148,7 +148,7 @@ impl<'a> Subreddit<'a> {
     /// use rawr::auth::PasswordAuthenticator;
     /// use rawr::client::RedditClient;
     /// use rawr::options::LinkPost;
-    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d"));
+    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d")).unwrap();
     /// let sub = client.subreddit("rust");
     /// let post = LinkPost::new("rawr!", "http://example.com");
     /// sub.submit_link(post).expect("Posting failed!");
@@ -170,7 +170,7 @@ impl<'a> Subreddit<'a> {
     /// use rawr::auth::PasswordAuthenticator;
     /// use rawr::client::RedditClient;
     /// use rawr::options::SelfPost;
-    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d"));
+    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d")).unwrap();
     /// let sub = client.subreddit("rust");
     /// let post = SelfPost::new("I love rawr!", "You should download it *right now*!");
     /// sub.submit_text(post).expect("Posting failed!");
@@ -190,7 +190,7 @@ impl<'a> Subreddit<'a> {
     /// ```
     /// use rawr::client::RedditClient;
     /// use rawr::auth::AnonymousAuthenticator;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let learn_programming = client.subreddit("learnprogramming").about()
     ///     .expect("Could not fetch 'about' data");
     /// assert_eq!(learn_programming.display_name(), "learnprogramming");

--- a/src/structures/user.rs
+++ b/src/structures/user.rs
@@ -27,7 +27,7 @@ impl<'a> User<'a> {
     /// ```
     /// use rawr::client::RedditClient;
     /// use rawr::auth::AnonymousAuthenticator;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let user = client.user("Aurora0001").about().expect("User request failed");
     /// assert_eq!(user.id(), "eqyvc");
     /// ```
@@ -66,7 +66,7 @@ impl<'a> User<'a> {
     /// # Examples
     /// ```
     /// use rawr::prelude::*;
-    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new());
+    /// let client = RedditClient::new("rawr", AnonymousAuthenticator::new()).unwrap();
     /// let user = client.user("Aurora0001");
     /// let submissions = user.submissions().expect("Could not fetch!");
     /// let mut i = 0;


### PR DESCRIPTION
Removed the use of unwrap in two cases

1. in RedditClient::new because it causes a panic if the login fails. Return a Result<> instead
2. in RedditClient::drop because it could cause an abort

The change in 1. defies the established convention of having ::new() return Self. Maybe it would be better to change the name of the function altogether. But since this is a library it should be possible to recover from the error.
