### PR TITLE
Derive clone on Submission struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 src/responses/*.out
+/.idea

--- a/src/responses/comment.rs.in
+++ b/src/responses/comment.rs.in
@@ -13,7 +13,7 @@ pub type NewComment = JSONWrapper<CommentThings>;
 /// A deserializable structure representing a comment. This is created when the client returns
 /// JSON representing a comment and this is wrapped in a `models::comment::Comment` for
 /// ease-of-use.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Comment {
     /// The Reddit ID for the subreddit where this was posted, **including the leading `t5_`**.
     pub subreddit_id: String,
@@ -100,7 +100,7 @@ pub struct Comment {
     pub parent_id: String
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct More {
     pub count: u64,
     pub parent_id: String,

--- a/src/responses/listing.rs.in
+++ b/src/responses/listing.rs.in
@@ -54,7 +54,7 @@ pub struct ListingData<T> {
 }
 
 /// Represents all types of link posts and self posts on Reddit.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Submission {
     /// The domain of the link (if link post) or self.subreddit (if self post).
     /// Domains do not include a protocol, e.g. `i.redd.it` or `self.learnprogramming`

--- a/src/structures/comment.rs
+++ b/src/structures/comment.rs
@@ -10,6 +10,7 @@ use responses::comment::{Comment as _Comment, CommentListing, NewComment};
 use errors::APIError;
 
 /// Structure representing a comment and its associated data (e.g. replies)
+#[derive(Clone)]
 pub struct Comment<'a> {
     data: _Comment,
     client: &'a RedditClient,

--- a/src/structures/comment_list.rs
+++ b/src/structures/comment_list.rs
@@ -32,6 +32,7 @@ use traits::Content;
 /// // fetches it for us!
 /// let comments = announcement.replies().expect("Could not get comments").take(100);
 /// ```
+#[derive(Clone)]
 pub struct CommentList<'a> {
     client: &'a RedditClient,
     comments: Vec<Comment<'a>>,

--- a/src/structures/comment_list.rs
+++ b/src/structures/comment_list.rs
@@ -110,9 +110,9 @@ impl<'a> CommentList<'a> {
                     let mut result_str = String::new();
                     res.read_to_string(&mut result_str).unwrap();
                     let mut new_listing: Value = from_str(&result_str).unwrap();
-                    let mut new_listing = new_listing.as_object_mut().unwrap();
+                    let new_listing = new_listing.as_object_mut().unwrap();
                     let mut json = new_listing.remove("json").unwrap();
-                    let mut json = json.as_object_mut().unwrap();
+                    let json = json.as_object_mut().unwrap();
                     let data = json.remove("data");
                     if let Some(mut data) = data {
                         let mut things = data.as_object_mut().unwrap();

--- a/src/structures/submission.rs
+++ b/src/structures/submission.rs
@@ -13,6 +13,7 @@ use responses::comment::NewComment;
 use errors::APIError;
 
 /// Structure representing a link post or self post (a submission) on Reddit.
+#[derive(Clone)]
 pub struct Submission<'a> {
     data: listing::Submission,
     client: &'a RedditClient,

--- a/src/structures/subreddit.rs
+++ b/src/structures/subreddit.rs
@@ -117,7 +117,7 @@ impl<'a> Subreddit<'a> {
     /// let sub = client.subreddit("thanksobama");
     /// let mut top = sub.top(ListingOptions::default(), TimeFilter::AllTime)
     ///     .expect("Request failed");
-    /// assert_eq!(top.next().unwrap().title(), "Thanks Me");
+    /// assert_eq!(top.next().unwrap().title(), "Thanks Obama, for helping to protect the rights of over 9 million Americans.");
     /// ```
     pub fn top(&self, opts: ListingOptions, time: TimeFilter) -> Result<Listing, APIError> {
         let path = format!("top?{}&", time);

--- a/src/structures/user.rs
+++ b/src/structures/user.rs
@@ -81,6 +81,28 @@ impl<'a> User<'a> {
             .get_json::<_Listing>(&url, false)
             .and_then(|res| Ok(Listing::new(self.client, url, res.data)))
     }
+
+    /// Gets a list of posts and comments that the specified user has saved. This endpoint is a
+    /// listing and will continue yielding items until every item has been exhausted. This
+    /// endpoint cannot be accessed anonymously.
+    /// # Examples
+    /// ```rust,no_run
+    /// use rawr::prelude::*;
+    /// let client = RedditClient::new("rawr", PasswordAuthenticator::new("a", "b", "c", "d"));
+    /// let user = client.user("Aurora0001");
+    /// let saved = user.saved().expect("Could not fetch!");
+    /// let mut i = 0;
+    /// for saved_item in saved.take(5) {
+    ///     i += 1;
+    /// }
+    /// assert_eq!(i, 5);
+    /// ```
+    pub fn saved(&self) -> Result<Listing, APIError> {
+        let url = format!("/user/{}/saved?raw_json=1", self.name);
+        self.client
+            .get_json::<_Listing>(&url, true)
+            .and_then(|res| Ok(Listing::new(self.client, url, res.data)))
+    }
     // TODO: implement comment, overview, gilded listings etc.
 }
 


### PR DESCRIPTION
This PR adds the ability to clone a submission before calling `fn replies(self)` which consumes the original submission struct, allowing continued access to a submission after reading the comments. I also corrected a couple minor compiler warnings and fixed a test which was broken.